### PR TITLE
Use defaultModelName in place of _getDefaultModelName

### DIFF
--- a/src/OBJFile.js
+++ b/src/OBJFile.js
@@ -81,7 +81,7 @@ class OBJFile {
   }
 
   _parseObject(lineItems) {
-    const modelName = lineItems.length >= 2 ? lineItems[1] : this._getDefaultModelName();
+    const modelName = lineItems.length >= 2 ? lineItems[1] : this.defaultModelName;
     this.result.models.push({
       name: modelName,
       vertices: [],


### PR DESCRIPTION
#### Change Made

The `_getDefaultModelName` function doesn't exist, it threw an error for me when the obj file didn't have a name to parse.

The fix was to use `this.defaultModelName` instead.