### PR TITLE
add support for l statements

### DIFF
--- a/src/OBJFile.js
+++ b/src/OBJFile.js
@@ -46,6 +46,9 @@ class OBJFile {
         case 'vn': // Define a vertex normal for the current model
           this._parseVertexNormal(lineItems);
           break;
+        case 'l': // Define a line for the current model
+          this._parseLine(lineItems);
+          break;
         case 's': // Smooth shading statement
           this._parseSmoothShadingStatement(lineItems);
           break;
@@ -87,7 +90,8 @@ class OBJFile {
       vertices: [],
       textureCoords: [],
       vertexNormals: [],
-      faces: []
+      faces: [],
+      lines: []
     });
     this.currentGroup = '';
     this.smoothingGroup = 0;
@@ -121,6 +125,31 @@ class OBJFile {
     const z = lineItems.length >= 4 ? parseFloat(lineItems[3]) : 0.0;
 
     this._currentModel().vertexNormals.push({ x, y, z });
+  }
+
+  _parseLine(lineItems) {
+    const totalVertices = (lineItems.length - 1);
+    if (totalVertices < 2) { throw (`Line statement has less than 2 vertices${this.filePath}${this.lineNumber}`); }
+
+    const line = [];
+
+    for (let i = 0; i < totalVertices; i += 1) {
+      const vertexString = lineItems[i + 1];
+      const vertexValues = vertexString.split('/');
+
+      if (vertexValues.length < 1 || vertexValues.length > 2) { throw (`Too many values (separated by /) for a single vertex${this.filePath}${this.lineNumber}`); }
+
+      let vertexIndex = 0;
+      let textureCoordsIndex = 0;
+      vertexIndex = parseInt(vertexValues[0]);
+      if (vertexValues.length > 1 && (vertexValues[1] != '')) { textureCoordsIndex = parseInt(vertexValues[1]); }
+
+      line.push({
+        vertexIndex,
+        textureCoordsIndex
+      });
+    }
+    this._currentModel().lines.push(line);
   }
 
   _parsePolygon(lineItems) {

--- a/tests/OBJFile.test.js
+++ b/tests/OBJFile.test.js
@@ -72,7 +72,8 @@ describe('OBJ File Parser', () => {
   describe('Polygon Definition', () => {
     it('f statements throw an error if given less than 3 vertices', () => {
       const fileContents = "f 1 2";
-      expect(new OBJFile(fileContents).parse).toThrow();
+      const obj = new OBJFile(fileContents);
+      expect(obj.parse.bind(obj)).toThrow("Face statement has less than 3 vertices");
     });
 
     it('f statements with single values define a face with the given vertex indices', () => {

--- a/tests/OBJFile.test.js
+++ b/tests/OBJFile.test.js
@@ -69,6 +69,62 @@ describe('OBJ File Parser', () => {
     });
   });
 
+  describe('Line Definition', () => {
+    it('all models have lines property', () => {
+      const fileContents = "o lineseg";
+      const model = new OBJFile(fileContents).parse().models[0];
+      expect(model.lines).not.toBe(undefined);
+    });
+
+    it('l statements are supported', () => {
+      const fileContents = "o lineseg\nv 1.0 2.0 -1.0\nv 3.0 2.0 0.0\nv 1.0 4.0 0.0\nl 1 3\nl 3 2";
+      const model = new OBJFile(fileContents).parse().models[0];
+      expect(model.lines.length).toBe(2);
+      expect(model.lines[0]).toEqual([
+        { vertexIndex: 1, textureCoordsIndex: 0 },
+        { vertexIndex: 3, textureCoordsIndex: 0 }
+      ]);
+      expect(model.lines[1]).toEqual([
+        { vertexIndex: 3, textureCoordsIndex: 0 },
+        { vertexIndex: 2, textureCoordsIndex: 0 }
+      ]);
+    });
+
+    it('l statements with n entries', () => {
+      const fileContents = "o lineseg\nv 1.0 2.0 -1.0\nv 3.0 2.0 0.0\nv 1.0 4.0 0.0\nl 1 3 2";
+      const model = new OBJFile(fileContents).parse().models[0];
+      expect(model.lines.length).toBe(1);
+      expect(model.lines[0]).toEqual([
+        { vertexIndex: 1, textureCoordsIndex: 0 },
+        { vertexIndex: 3, textureCoordsIndex: 0 },
+        { vertexIndex: 2, textureCoordsIndex: 0 }
+      ]);
+    });
+
+    it('l statements with texture coords', () => {
+      const fileContents = "o lineseg\nl 1/4 3/6 2/5";
+      const model = new OBJFile(fileContents).parse().models[0];
+      expect(model.lines.length).toBe(1);
+      expect(model.lines[0]).toEqual([
+        { vertexIndex: 1, textureCoordsIndex: 4 },
+        { vertexIndex: 3, textureCoordsIndex: 6 },
+        { vertexIndex: 2, textureCoordsIndex: 5 }
+      ]);
+    });
+
+    it('l statements throws an error if given less than 2 vertices', () => {
+      const fileContents = "l 1";
+      const obj = new OBJFile(fileContents);
+      expect(obj.parse.bind(obj)).toThrow("Line statement has less than 2 vertices");
+    });
+
+    it('l statements throws an error if vertex has more than 1 slash', () => {
+      const fileContents = "l 1//7 2//8";
+      const obj = new OBJFile(fileContents);
+      expect(obj.parse.bind(obj)).toThrow("Too many values (separated by /) for a single vertex");
+    });
+  });
+
   describe('Polygon Definition', () => {
     it('f statements throw an error if given less than 3 vertices', () => {
       const fileContents = "f 1 2";


### PR DESCRIPTION
This PR adds support for l statements (line segments). I've added tests that are as rigorous as the existing tests in the code.

I also fixed a test in your existing code that wasn't properly testing (it required `.bind()`) to work properly.